### PR TITLE
Add missing </TD> closing tag

### DIFF
--- a/src/scoretable.php
+++ b/src/scoretable.php
@@ -314,7 +314,7 @@ if($redo) {
 		else {
 */
 			$_SESSION["scoreblink"][$score[$e]["username"]."-".$score[$e]["site"]]=0;
-			$strtmp .= "  <td nowrap>" . $score[$e]["username"]."/".$score[$e]["site"] . " ";
+			$strtmp .= "  <td nowrap>" . $score[$e]["username"]."/".$score[$e]["site"] . " </td>";
 			$strtmp .= "<td>" . $score[$e]["userfullname"];
 //		}
 		$_SESSION["scorepos"][$score[$e]["username"]."-".$score[$e]["site"]] = $cg2;


### PR DESCRIPTION
I wrote a simple script to parse the HTML output of the scoreboard and the HTML parser broke while parsing the broken <TD> with the missing </TD> tag.
