### PR TITLE
split css for score

### DIFF
--- a/src/Css.php
+++ b/src/Css.php
@@ -86,4 +86,3 @@ p.link a:hover span {
   text-align:left;
   display: block;
 }
-<?php for($i=1;$i<999;$i++) echo "table.sitehide$i .sitegroup$i { display: none; }\n"; ?>

--- a/src/ScoreCss.php
+++ b/src/ScoreCss.php
@@ -1,0 +1,1 @@
+<?php for($i=1;$i<999;$i++) echo "table.sitehide$i .sitegroup$i { display: none; }\n"; ?>

--- a/src/scorelower.php
+++ b/src/scorelower.php
@@ -42,6 +42,8 @@ else $des=true;
 //if ($s["currenttime"] >= $s["sitelastmilescore"] && $ver)
 //	echo "<br><center>Scoreboard frozen</center>";
 
+echo "<link rel=stylesheet href=\"../ScoreCss.php\" type=\"text/css\">\n";
+
 require('scoretable.php');
 ?>
 


### PR DESCRIPTION
Este commit diminui o tamanho da maior parte das páginas do Boca.

Esse commit divide o arquivo de CSS do boca em 2 arquivos:

- O primeiro arquivo contém todo o conteúdo do arquivo original, menos a última linha.
- O segundo arquivo contém apenas a última linha do arquivo original.

Este segundo arquivo contém classes usadas apelas pelo scoreboard, e agora só é incluido no scoreboard.