### PR TITLE
Since PHP 7, the function get_magic_quotes_gpc() was deprecated and

### DIFF
--- a/src/globals.php
+++ b/src/globals.php
@@ -24,10 +24,6 @@ function sanitizeVariables(&$item, $key)
 { 
     if (!is_array($item)) 
     { 
-        // undoing 'magic_quotes_gpc = On' directive 
-        if (get_magic_quotes_gpc()) 
-            $item = stripcslashes($item); 
-        
         $item = sanitizeText($item); 
     } 
 } 


### PR DESCRIPTION
always returned false. Thus, the code removed by the commit is
unreachable.
In PHP8 the function was removed.