### PR TITLE
Fix user multi-login problem when running BOCA with a reverse proxy

### DIFF
--- a/src/flog.php
+++ b/src/flog.php
@@ -177,7 +177,9 @@ function DBLogInContest($name,$pass,$contest,$msg=true) {
 	    unset($_SESSION["usertable"]);
 	    return false;
 	  }
-	  if($prevuser != $ccode && $a["usertype"] == "team") {
+	  // Do not allow a team to log in from another computer/user agent only
+	  // if the usermultilogin option is disabled
+	  if($prevuser != $ccode && $a["usertype"] == "team" && $a["usermultilogin"] != "t") {
 	    LOGLevel("User $name tried to log in contest $contest but computer is invalid ($ccode).",2);
 	    if($msg) MSGError("Invalid computer (3).");
 	    unset($_SESSION["usertable"]);


### PR DESCRIPTION
#### Reference Issues
The proposed approach addresses the user multi-logins issue reported at #18.

#### What does this implement/fix?
This pull request includes a code fix to enable user multi-logins when BOCA runs behind a reverse proxy (that allows a custom URL as inf.university.br/boca). The problem occurs because in such a setup the registered User IP will be always fixed (it is the same as the reverse proxy) and it will not allow a team to log in from different browsers (even when the `MultiLogins` option is set to '_Yes_').

This fix can be quite useful to run remote programing contests, in which even the team members are non-collocated, as well as for educational purposes (I use it as a remote self-paced tool in the programming courses at the Federal University of Espírito Santo ([UFES](https://ufes.br/), Brazil).

#### How to test it?

##### Option 1: Install from source

1. After that, go to the user test;

##### Option 2: Build Docker images

_docker-compose.yml_
````
version: '3'

services:

    traefik:
        image: "traefik:v2.6"
        container_name: "traefik"
        command:
              #- "--log.level=DEBUG"
              - "--api.insecure=true"
              - "--providers.docker=true"
              - "--providers.docker.exposedbydefault=false"
              - "--entrypoints.web.address=:80"
        ports:
              - "80:80"
              - "8080:8080"
        volumes:
            - "/var/run/docker.sock:/var/run/docker.sock:ro"

    boca-web:
        image: ghcr.io/joaofazolo/boca-docker/boca-web
        privileged: true
        restart: unless-stopped
        depends_on:
            - boca-postgres
        environment:
            # Database configuration
            - DB_HOST=boca-postgres
            - DB_PORT=5432
            - DB_NAME=bocadb
            # unprivileged boca user
            - DB_USER=bocauser
            - DB_PASSWORD=dAm0HAiC
            # privileged boca user
            - DB_SUPER_USER=bocauser
            - DB_SUPER_PASSWORD=dAm0HAiC
            # initial password that is used by the admin user (web app)
            # If not set, the default value is 'boca'
            - BOCA_PASSWORD=boca
            # secret key to be used in HTTP headers
            # MUST set it with any random large enough sequence
            - BOCA_KEY=GG56KFJtNDBGjJprR6ex
        labels:
            - "traefik.enable=true"
            - "traefik.http.routers.boca.rule=Host(`localhost`) && PathPrefix(`/boca`)"
            - "traefik.http.routers.boca.entrypoints=web"
            - "traefik.http.services.boca.loadbalancer.server.port=80"

    boca-jail:
        image: ghcr.io/joaofazolo/boca-docker/boca-jail
        privileged: true
        restart: unless-stopped
        depends_on:
            - boca-postgres
        environment:
            # Database configuration
            - DB_HOST=boca-postgres
            - DB_PORT=5432
            - DB_NAME=bocadb
            # unprivileged boca user
            - DB_USER=bocauser
            - DB_PASSWORD=dAm0HAiC
            - PASSWD=dAm0HAiC

    boca-postgres:
        image: postgres
        container_name: boca-postgres
        restart: unless-stopped
        environment:
            # Database configuration
            # privileged boca user
            POSTGRES_USER: bocauser
            POSTGRES_PASSWORD: dAm0HAiC

````

1. Follow the instructions to [build](https://github.com/joaofazolo/boca-docker#how-to-build-it) and [publish](https://github.com/joaofazolo/boca-docker#how-to-publish-it) the boca-docker images created from source (be sure that the code includes the proposed fix);
1. Download/save the file _docker-compose.yml_ and place it in the shell current directory. Run the command below and  follow the user test;

        docker-compose -f docker-compose.yml up -d

<img width="1076" alt="Screen Shot 2022-05-20 at 10 38 06" src="https://user-images.githubusercontent.com/4059310/169546553-13b4feef-3f1a-45cd-bffe-53243d867c60.png">

##### User test

1. Open a Web browser, visit [localhost/boca](http://localhost/boca/) and log in with the credentials `Name: system | Password: boca`;
1. Click on the '_Contest_' menu (top/left) and select '_new_' in the ComboBox;
1. Leave the form as it is, click on the button '_Send_' (confirm it) and then on '_Activate_' (confirm it). You will be automatically logged out;
1. Log in with the credentials `Name: admin | Password: boca`;
1. Click on the '_Users_' menu and fill in the form with the information below (**IMPORTANT: the MultiLogins field must be set to YES**). Click on the '_Send_' button. The new user must appear in the list. After that, just log out.
```
    User Site Number: 1
    User Number: 2000
    Username: topcoder
    ICPC ID: 
    Type: Team
    Enabled: Yes
    MultiLogins (local teams should be set to No): Yes
    User Full Name: 
    User Description: 
    User IP: 
    Password: boca
    Retype Password: boca
    Allow password change: No
    Admin (this user) Password: boca
```
1. Finally, you should be able to log in from 2 different User Agents (Web browsers) using the credentials `Name: topcoder | Password: boca`. To stop the application (considering that the shell is in the same directory):

        docker-compose -f docker-compose.yml down

<img width="1072" alt="Screen Shot 2022-05-20 at 07 13 58" src="https://user-images.githubusercontent.com/4059310/169548210-4624e99a-ee4e-4f62-adfc-f0737b98b6fc.png">
<img width="1072" alt="Screen Shot 2022-05-20 at 07 13 42" src="https://user-images.githubusercontent.com/4059310/169548228-53d9a954-7acb-461d-ab7c-9f2a128db587.png">
<img width="1072" alt="Screen Shot 2022-05-20 at 07 14 52" src="https://user-images.githubusercontent.com/4059310/169549911-481b0f2a-6a07-407b-85ed-aabdde794fe8.png">
<img width="1072" alt="Screen Shot 2022-05-20 at 11 40 41" src="https://user-images.githubusercontent.com/4059310/169551984-49a9e4c2-93b2-4e12-9db5-f0bc6dd6f546.png">

#### Other Comments
Feel free to suggest other approaches to address the problem.
