### PR TITLE
Fix autojudge (jail) behavior (no need to restart if it is executed before a contest is activated or if the active contest changes over time)

### DIFF
--- a/src/private/autojudging.php
+++ b/src/private/autojudging.php
@@ -79,10 +79,10 @@ $key=md5(mt_rand() . rand() . mt_rand());
 
 $cf = globalconf();
 $ip = $cf["ip"];
-$activecontest=DBGetActiveContest();
 $prevsleep=0;
 //$dodebug=1;
 while(42) {
+  $activecontest=DBGetActiveContest();
 
   if(($run = DBGetRunToAutojudging($activecontest["contestnumber"], $ip)) === false) {
     if($prevsleep==0)


### PR DESCRIPTION
#### Reference Issues
The proposed approach addresses the autojudge (jail) issue/behavior reported at #29.

#### What does this implement/fix?
This pull request includes a code fix that enables autojudge to judge submissions (runs) even if it is started before a contest is created and activated, or in case the active contest changes over time in the BOCA intance. The problem occurs because in the autojudge code the variable that holds the active contest is set in the beginning and never updated inside the infinite loop. With this PR, once the autojudge is up and running there is no need to manually restart it every single time a contest is created and activated. Although creating and activating different contests on the same host machine might not be a frequent use case, this imposes a caveat.

#### How to test it?
Follow the steps described at at #29.

#### Other Comments
Feel free to suggest other approaches to address the problem.
