### PR TITLE
New autojudge setting on interface per problem.

### DIFF
--- a/src/admin/answer.php
+++ b/src/admin/answer.php
@@ -37,6 +37,7 @@ if (isset($_POST["Submit3"]) && isset($_POST["answernumber"]) && is_numeric($_PO
 		$param["number"] = $_POST["answernumber"];
 		$param["name"] = $_POST["answername"];
 		$param["yes"] = $_POST["answeryes"];
+		$param["short"] = $_POST["answershort"];
 		DBNewAnswer ($_SESSION["usertable"]["contestnumber"],$param);
 	}
 	ForceLoad("answer.php");
@@ -65,6 +66,7 @@ if (isset($_POST["Submit3"]) && isset($_POST["answernumber"]) && is_numeric($_PO
  <tr>
   <td><b>Answer #</b></td>
   <td><b>Description</b></td>
+  <td><b>Shortname</b></td>
   <td><b>Yes/No</b></td>
  </tr>
 <?php
@@ -82,8 +84,13 @@ for ($i=0; $i<count($ans); $i++) {
       echo "  <td nowrap>".$ans[$i]["number"]." (fake)</td>\n";
     }
     echo " <td nowrap>" . $ans[$i]["desc"] . "</td>\n";
+    
+    if ($ans[$i]["short"]=="") echo "  <td nowrap>&lt;EMPTY&gt;</td>\n";
+    else echo "  <td nowrap>".$ans[$i]["short"]."</td>\n";
+    
     if($ans[$i]["yes"]=="t") echo "  <td nowrap>Yes</td>\n";
     else echo "  <td nowrap>No</td>\n";
+    
     echo " </tr>\n";
     $n++;
 }
@@ -111,6 +118,12 @@ if ($n == 0) echo "<br><center><b><font color=\"#ff0000\">NO ANSWERS DEFINED</fo
         <td width="35%" align=right>Description:</td>
         <td width="65%">
           <input type="text" name="answername" value="" size="50" maxlength="50" />
+        </td>
+      </tr>
+      <tr>
+        <td width="35%" align=right>Shortname (usually 2 or 3 letters):</td>
+        <td width="65%">
+          <input type="text" name="answershort" value="" size="20" maxlength="20" />
         </td>
       </tr>
       <tr>

--- a/src/fcontest.php
+++ b/src/fcontest.php
@@ -1083,24 +1083,24 @@ function insertlanguages($n,$c=null) {
 	DBNewLanguage($n, $param, $c);
 }
 function insertanswers($n,$c) {
-	DBExec($c, "insert into answertable (contestnumber, answernumber, runanswer, yes, fake) values ".
-			"($n, 0, 'Not answered yet', 'f', 't')", "DBNewContest(insert fake answer)");
-	DBExec($c, "insert into answertable (contestnumber, answernumber, runanswer, yes, fake) values ".
-			"($n, 1, 'YES', 't', 'f')", "DBNewContest(insert YES answer)");
-	DBExec($c, "insert into answertable (contestnumber, answernumber, runanswer, yes, fake) values ".
-			"($n, 2, 'NO - Compilation error', 'f', 'f')", "DBNewContest(insert CE answer)");
-	DBExec($c, "insert into answertable (contestnumber, answernumber, runanswer, yes, fake) values ".
-			"($n, 3, 'NO - Runtime error', 'f', 'f')", "DBNewContest(insert RE answer)");
-	DBExec($c, "insert into answertable (contestnumber, answernumber, runanswer, yes, fake) values ".
-			"($n, 4, 'NO - Time limit exceeded', 'f', 'f')", "DBNewContest(insert TLE answer)");
-	DBExec($c, "insert into answertable (contestnumber, answernumber, runanswer, yes, fake) values ".
-			"($n, 5, 'NO - Presentation error', 'f', 'f')", "DBNewContest(insert PE answer)");
-	DBExec($c, "insert into answertable (contestnumber, answernumber, runanswer, yes, fake) values ".
-			"($n, 6, 'NO - Wrong answer', 'f', 'f')", "DBNewContest(insert WA answer)");
-	DBExec($c, "insert into answertable (contestnumber, answernumber, runanswer, yes, fake) values ".
-			"($n, 7, 'NO - Contact staff', 'f', 'f')", "DBNewContest(insert CS answer)");
-	DBExec($c, "insert into answertable (contestnumber, answernumber, runanswer, yes, fake) values ".
-			"($n, 8, 'NO - Name mismatch', 'f', 'f')", "DBNewContest(insert MI answer)");
+	DBExec($c, "insert into answertable (contestnumber, answernumber, runanswer, shortname, yes, fake) values ".
+			"($n, 0, 'Not answered yet', 'NYET', 'f', 't')", "DBNewContest(insert fake answer)");
+	DBExec($c, "insert into answertable (contestnumber, answernumber, runanswer, shortname, yes, fake) values ".
+			"($n, 1, 'YES', 'YES', 't', 'f')", "DBNewContest(insert YES answer)");
+	DBExec($c, "insert into answertable (contestnumber, answernumber, runanswer, shortname, yes, fake) values ".
+			"($n, 2, 'NO - Compilation error', 'CE', 'f', 'f')", "DBNewContest(insert CE answer)");
+	DBExec($c, "insert into answertable (contestnumber, answernumber, runanswer, shortname, yes, fake) values ".
+			"($n, 3, 'NO - Runtime error', 'RE', 'f', 'f')", "DBNewContest(insert RE answer)");
+	DBExec($c, "insert into answertable (contestnumber, answernumber, runanswer, shortname, yes, fake) values ".
+			"($n, 4, 'NO - Time limit exceeded', 'TLE','f', 'f')", "DBNewContest(insert TLE answer)");
+	DBExec($c, "insert into answertable (contestnumber, answernumber, runanswer, shortname, yes, fake) values ".
+			"($n, 5, 'NO - Presentation error', 'PE', 'f', 'f')", "DBNewContest(insert PE answer)");
+	DBExec($c, "insert into answertable (contestnumber, answernumber, runanswer, shortname, yes, fake) values ".
+			"($n, 6, 'NO - Wrong answer', 'WA', 'f', 'f')", "DBNewContest(insert WA answer)");
+	DBExec($c, "insert into answertable (contestnumber, answernumber, runanswer, shortname, yes, fake) values ".
+			"($n, 7, 'NO - Contact staff', 'CS', 'f', 'f')", "DBNewContest(insert CS answer)");
+	DBExec($c, "insert into answertable (contestnumber, answernumber, runanswer, shortname, yes, fake) values ".
+			"($n, 8, 'NO - Name mismatch', 'NMI', 'f', 'f')", "DBNewContest(insert MI answer)");
 }
 function DBNewSite ($contest, $c=null, $param=array()) {
 	$cw = false;

--- a/src/frun.php
+++ b/src/frun.php
@@ -484,34 +484,28 @@ function DBUpdateRunAutojudging($contest, $site, $number, $ip, $answer, $stdout,
 		   "DBUpdateRunAutojudging(update run)");
 
 	$b = DBSiteInfo($contest, $site, $c);
-
-	if($b["siteautojudge"]!="t") {
+	
+	/* If the global config for this site says "NO Autojudge" return the script now */
+	if($b["siteautojudge"]=="f") {
 	  DBExec($c, "commit work", "DBUpdateRunAutojudging(commit)");
 	  LOGLevel("Autojudging answered a run (run=$number, site=$site, contest=$contest, answer='$answer', retval=$retval)", 3);
 	  return true;
 	}
-	/* // tricks that can be used to make automatic answering for some problems and types of answers. However, this should be integrated into the system in a smart way soon
-	  if(true || //cassiopc remove the true here if you want this to take effect
-	     (($retval != 1 || // for some problems, 1:YES is not automatic
-	       $a["runproblem"] == 1 ||
-	       $a["runproblem"] == 2 ||
-	       $a["runproblem"] == 3 ||
-	       $a["runproblem"] == 4 ||
-	       $a["runproblem"] == 5 ||
-	       $a["runproblem"] == 6 ||
-	       $a["runproblem"] == 7 ||
-	       $a["runproblem"] == 8 ||
-	       $a["runproblem"] == 9 ||
-	       $a["runproblem"] == 10 ||
-	       $a["runproblem"] == 11 ||
-	       $a["runproblem"] == 12 ||
-	       $a["runproblem"] == 13)
-	      && $retval != 4 && $retval != 6)) { // but WA:6 and TLE:4 are automatic for all problems
-	    if($retval != 1 && $retval != 6 && $retval != 4) {
-	    }
-	  }
+	
+	/* Next, check the problem setting, let's read what the autojudge config says about this problem */
+	$problem_data = DBGetProblemData($contest, $a['runproblem']);
+	/* Compare the bit field from problem data to our answer,
+	 * if the bit on the problem data is set, it means that it should be auto-judged
+	 * if zero, do nothing
+	 */
+	$autojudge_setting = ((integer) $problem_data[0]['autojudge']);
+	$mask = pow (2, $retval);
+	if (($autojudge_setting & $mask) == 0) {
+		DBExec($c, "commit work", "DBUpdateRunAutojudging(commit)");
+		LOGLevel("Autojudging answered a run (run=$number, site=$site, contest=$contest, answer='$answer', retval=$retval)", 3);
+		return true;
 	}
-	*/
+	
 	//echo "DEBUG: $contest, $site, " .$a["usernumber"].", $site, $number, $retval\n";
 	if(DBUpdateRunO($contest, $site, $a["usernumber"], $site, $number, $retval, $c)==false) {
 		DBExec($c, "rollback work", "DBUpdateRunAutoJudging(rollback)");


### PR DESCRIPTION
* First obey the global 'autojudge' setting per site.
* Next, check the setting per problem per answer type.
* By default autoanswer is enabled on all problems.