### PR TITLE
Fixed issue when color problem is updated

### DIFF
--- a/src/admin/problem.php
+++ b/src/admin/problem.php
@@ -231,6 +231,9 @@ for ($i=0; $i<count($prob); $i++) {
 	$param['fake'] = 'f';
 	$param['colorname'] = trim($_POST["colorname" . $prob[$i]['number']]);
 	$param['color'] = trim($_POST["color" . $prob[$i]['number']]);
+	if (isset ($prob[$i]['autojudge'])) {
+		$param['autojudge'] = ((integer) $prob[$i]['autojudge']);
+	}
 	DBNewProblem ($_SESSION["usertable"]["contestnumber"], $param);
       }
       ForceLoad("problem.php");


### PR DESCRIPTION
There is a small issue, when a color, or color name is update on a problem using the table, the autojudge setting is set to none.

This pull request fixes the issue.