### PR TITLE
[Interactive] Ensure fifo files are not written to while cleaning dir in bocajail

### DIFF
--- a/src/globals.php
+++ b/src/globals.php
@@ -169,7 +169,7 @@ function cleardir($dir,$cddir=true,$secure=true,$removedir=true) {
 		if($removedir)
 		  @rmdir($dir);
 	} else {
-	  if($secure && !is_link($dir))
+	  if($secure && !is_link($dir) && is_file($dir))
 	    file_put_contents($dir,str_repeat('XXXXXXXXXX',10000));
 	  @unlink($dir);
 	}


### PR DESCRIPTION
This change allows us to build a package for BOCA to judge interactive problems.

We've used this fix in Maratona Mineira, which worked pretty well, and the packages behaved fine during the competition. We still plan to do more testing on this package, but the important point here is: the judging script creates a couple `fifo.in` and `fifo.out` files for the processes to communicate.

The issue here is that, writing to those FIFO files when there isn't another process reading from it on the other side makes the writer process to hang indefinitely. This is an issue because of this line in  `globals.php` that overwrites all files in bocajail with `XXX` before cleaning them up between each judging execution (probably some sort of security measure I suppose...).

Even though the script can clean up after itself, thus essentially always removing those two files after usage, if the autojudge halts (or even is interrupted with a Ctrl+C) and the script ends before the clean up, the file will be left in the bocajail dir and, in the next autojudge run, the autojudge will try to clean and hang. This will rarely happen in practice, but is super dangerous and hard to debug (it happened to me during manual testing, never during a competition, but better be safe than sorry).

Other options were:
- Not use FIFO files in the interactive problem package (i.e. use pipes directly) but this would be way harder to implement with `safeexec`
- Remove this XXX line altogether if this is just legacy code that isn't important (I'm not a security expert, but I can see that users could potentially find a breach here, so I'm not the person to make that call)