### PR TITLE
Feature - Submission counter at problems dashborad (team's page)

### DIFF
--- a/src/team/problem.php
+++ b/src/team/problem.php
@@ -64,6 +64,24 @@ $prob = DBGetProblems($_SESSION["usertable"]["contestnumber"]);
 $subcounts = array();
 $accepteds = array();
 $c = DBConnect();
+
+$contest_start = isset($ct['conteststart']) ? strtotime($ct['conteststart']) : null;
+$ta = $contest_start ? max(0, intval((time() - $contest_start) / 60)) : 0;
+
+if (($blocal = DBSiteInfo($contest, $_SESSION["usertable"]["usersitenumber"])) == null)
+  exit;
+if (($b = DBSiteInfo($contest, $site, null, false)) == null)
+  $b=$blocal;
+if (($ct = DBContestInfo($contest)) == null)
+  exit;
+
+
+if ($verifylastmile)
+  $tf = $b["sitelastmilescore"];
+else
+  $tf = $b["siteduration"];
+
+
 $contest = $_SESSION["usertable"]["contestnumber"];
 $q = "SELECT r.runproblem AS problem,
         count(*) AS cnt, -- Sua contagem original (total de envios)
@@ -75,7 +93,9 @@ $q = "SELECT r.runproblem AS problem,
      AND r.contestnumber = $contest
      AND u.contestnumber = $contest
      AND (NOT r.runstatus ~ 'deleted')
+     AND r.rundatediff>=0 and r.rundatediff<=$tf and r.rundatediffans<=$ta
      GROUP BY r.runproblem";
+     
 $r = DBExec($c, $q, "problem(get submissions)");
 $nsub = DBnlines($r);
 for($si=0;$si<$nsub;$si++) {

--- a/src/team/problem.php
+++ b/src/team/problem.php
@@ -63,10 +63,10 @@ $prob = DBGetProblems($_SESSION["usertable"]["contestnumber"]);
 // gather submission counts per problem (only team users, exclude deleted runs)
 $subcounts = array();
 $accepteds = array();
-$c = DBConnect();
 
 $contest = $_SESSION["usertable"]["contestnumber"];
 $site = $_SESSION["usertable"]["usersitenumber"];
+
 if (($blocal = DBSiteInfo($contest, $_SESSION["usertable"]["usersitenumber"])) == null)
   exit;
 if (($b = DBSiteInfo($contest, $site, null, false)) == null)
@@ -77,28 +77,11 @@ if (($ct = DBContestInfo($contest)) == null)
 $ta = $blocal["currenttime"];
 $t_freeze = $b["sitelastmilescore"]; 
 
-$q = "SELECT r.runproblem AS problem,
-        count(*) AS cnt, -- Sua contagem original (total de envios)
-        COUNT(*) FILTER (WHERE a.yes = true) AS cnt_yes -- A nova contagem (apenas 'yes')
-     FROM runtable r
-     JOIN usertable u ON r.usernumber = u.usernumber
-     JOIN answertable a on r.runanswer = a.answernumber and a.contestnumber= $contest
-     WHERE u.usertype = 'team'
-     AND r.contestnumber = $contest
-     AND u.contestnumber = $contest
-     AND r.runsitenumber = $site
-     AND u.usersitenumber = $site
-     AND (NOT r.runstatus ~ 'deleted')
-     AND r.rundatediff >= 0 and r.rundatediff <= $t_freeze and r.rundatediffans <= $ta
-    GROUP BY r.runproblem";
+$counts = DBGetProblemSubmissionCounts($contest, $site, $t_freeze, $ta);
+$subcounts = $counts['subcounts'];
+$accepteds = $counts['accepteds'];
 
-$r = DBExec($c, $q, "problem(get submissions)");
-$nsub = DBnlines($r);
-for($si=0;$si<$nsub;$si++) {
-  $row = DBRow($r,$si);
-  $subcounts[$row['problem']] = $row['cnt'];
-  $accepteds[$row['problem']] = $row['cnt_yes'];
-}
+
 for ($i=0; $i<count($prob); $i++) {
   echo " <tr>\n";
 //  echo "  <td nowrap>" . $prob[$i]["number"] . "</td>\n";


### PR DESCRIPTION
This change allows viewing, on the problems dashboard, the submission counter for each problem (total and accepted) during the contest.

It basically reflects the information already available on the scoreboard to the problems dashboard, including the restriction on the submissions sent during the frozen time.

The way the information is presented on the problems page is X/Y, where X corresponds to the number of accepted submissions and Y to the total number of submissions sent for the problem.

<img width="1914" height="222" alt="image" src="https://github.com/user-attachments/assets/297489ef-92f0-4101-bcaf-afcfbbb69ab3" />
